### PR TITLE
feat(codegen): Add support to move action recording

### DIFF
--- a/packages/playwright-core/src/server/codegen/csharp.ts
+++ b/packages/playwright-core/src/server/codegen/csharp.ts
@@ -133,6 +133,11 @@ export class CSharpLanguageGenerator implements LanguageGenerator {
         const shortcut = [...modifiers, action.key].join('+');
         return `await ${subject}.${this._asLocator(action.selector)}.PressAsync(${quote(shortcut)});`;
       }
+      case 'move':
+        // const options: MouseClickOptions = action.button !== 'left' ? { button: action.button } : {};
+        return [
+
+        ].join('\n');
       case 'navigate':
         return `await ${subject}.GotoAsync(${quote(action.url)});`;
       case 'select':

--- a/packages/playwright-core/src/server/codegen/java.ts
+++ b/packages/playwright-core/src/server/codegen/java.ts
@@ -120,6 +120,11 @@ export class JavaLanguageGenerator implements LanguageGenerator {
         const shortcut = [...modifiers, action.key].join('+');
         return `${subject}.${this._asLocator(action.selector, inFrameLocator)}.press(${quote(shortcut)});`;
       }
+      case 'move':
+        // const options: MouseClickOptions = action.button !== 'left' ? { button: action.button } : {};
+        return [
+
+        ].join('\n');
       case 'navigate':
         return `${subject}.navigate(${quote(action.url)});`;
       case 'select':

--- a/packages/playwright-core/src/server/codegen/javascript.ts
+++ b/packages/playwright-core/src/server/codegen/javascript.ts
@@ -21,6 +21,7 @@ import { deviceDescriptors } from '../deviceDescriptors';
 import type { Language, LanguageGenerator, LanguageGeneratorOptions } from './types';
 import type { BrowserContextOptions } from '../../../types/types';
 import type * as actions from '@recorder/actions';
+import type { MouseClickOptions } from '../types';
 
 export class JavaScriptLanguageGenerator implements LanguageGenerator {
   id: string;
@@ -104,6 +105,20 @@ export class JavaScriptLanguageGenerator implements LanguageGenerator {
         const shortcut = [...modifiers, action.key].join('+');
         return `await ${subject}.${this._asLocator(action.selector)}.press(${quote(shortcut)});`;
       }
+      case 'move':
+        const options: MouseClickOptions = action.button !== 'left' ? { button: action.button } : {};
+        const modifiers = toKeyboardModifiers(action.modifiers);
+        const hoverOptionsString = formatOptions({
+          position: { x: action.hover.x, y: action.hover.y },
+          ...(modifiers.length ? { modifiers } : {})
+        }, false);
+        const buttonOptionsString = formatOptions(options, false);
+        return [
+          `await ${subject}.${this._asLocator(action.selector)}.hover(${hoverOptionsString});`,
+          `await ${subject}.mouse.down(${buttonOptionsString});`,
+          `await ${subject}.mouse.move(${action.up.x}, ${action.up.y}, { steps: ${action.steps} });`,
+          `await ${subject}.mouse.up(${buttonOptionsString});`
+        ].join('\n');
       case 'navigate':
         return `await ${subject}.goto(${quote(action.url)});`;
       case 'select':

--- a/packages/playwright-core/src/server/codegen/python.ts
+++ b/packages/playwright-core/src/server/codegen/python.ts
@@ -113,6 +113,13 @@ export class PythonLanguageGenerator implements LanguageGenerator {
         const shortcut = [...modifiers, action.key].join('+');
         return `${subject}.${this._asLocator(action.selector)}.press(${quote(shortcut)})`;
       }
+      case 'move':
+        // const modifiers = toModifiers(action.modifiers);
+        // const options: MouseClickOptions = action.button !== 'left' ? { button: action.button } : {};
+        // const optionsString = formatOptions(options, false);
+        return [
+
+        ].join('\n');
       case 'navigate':
         return `${subject}.goto(${quote(action.url)})`;
       case 'select':

--- a/packages/recorder/src/actions.d.ts
+++ b/packages/recorder/src/actions.d.ts
@@ -21,6 +21,7 @@ export type ActionName =
   'click' |
   'closePage' |
   'fill' |
+  'move' |
   'navigate' |
   'openPage' |
   'press' |
@@ -66,6 +67,16 @@ export type FillAction = ActionWithSelector & {
 export type NavigateAction = ActionBase & {
   name: 'navigate',
   url: string,
+};
+
+export type MoveAction = ActionWithSelector & {
+  name: 'move';
+  button: 'left' | 'middle' | 'right';
+  modifiers: number;
+  hover: Point;
+  down: Point;
+  up: Point;
+  steps: number;
 };
 
 export type OpenPageAction = ActionBase & {
@@ -119,9 +130,9 @@ export type AssertSnapshotAction = ActionWithSelector & {
   snapshot: string,
 };
 
-export type Action = ClickAction | CheckAction | ClosesPageAction | OpenPageAction | UncheckAction | FillAction | NavigateAction | PressAction | SelectAction | SetInputFilesAction | AssertTextAction | AssertValueAction | AssertCheckedAction | AssertVisibleAction | AssertSnapshotAction;
+export type Action = ClickAction | CheckAction | ClosesPageAction | OpenPageAction | UncheckAction | FillAction | NavigateAction | MoveAction | PressAction | SelectAction | SetInputFilesAction | AssertTextAction | AssertValueAction | AssertCheckedAction | AssertVisibleAction | AssertSnapshotAction;
 export type AssertAction = AssertCheckedAction | AssertValueAction | AssertTextAction | AssertVisibleAction | AssertSnapshotAction;
-export type PerformOnRecordAction = ClickAction | CheckAction | UncheckAction | PressAction | SelectAction;
+export type PerformOnRecordAction = ClickAction | CheckAction | UncheckAction | MoveAction | PressAction | SelectAction;
 
 // Signals.
 

--- a/tests/library/inspector/cli-codegen-1.spec.ts
+++ b/tests/library/inspector/cli-codegen-1.spec.ts
@@ -196,6 +196,58 @@ await page.Locator("canvas").ClickAsync(new LocatorClickOptions
     expect(message.text()).toBe('click 250 250');
   });
 
+  test('should make a down-move-up sequence on a canvas', async ({
+    openRecorder,
+  }) => {
+    const { recorder, page } = await openRecorder();
+
+    await recorder.setContentAndWait(`
+      <canvas width="500" height="500" style="margin: 42px"/>
+      <script>
+      document.querySelector("canvas").addEventListener("mouseup", event => {
+        const rect = event.target.getBoundingClientRect();
+        console.log("mouseup", event.clientX - rect.left, event.clientY - rect.top);
+      })
+      </script>
+    `);
+
+    const locator = await recorder.hoverOverElement('canvas', {
+      position: { x: 250, y: 250 },
+    });
+    expect(locator).toBe(`locator('canvas')`);
+    const [message, sources] = await Promise.all([
+      page.waitForEvent('console', msg => msg.type() !== 'error'),
+      recorder.waitForOutput('JavaScript', 'move'),
+      (async () => {
+        await page.locator('canvas').hover({ position: { x: 250, y: 250 } });
+        await page.mouse.down();
+        await page.mouse.move(500, 500, { steps: 5 });
+        await page.mouse.up();
+      })(),
+    ]);
+
+    expect(sources.get('JavaScript')!.text).toContain(`
+  await page.locator('canvas').hover({
+    position: {
+      x: 250,
+      y: 250
+    }
+  });
+  await page.mouse.down();
+  await page.mouse.move(500, 500, { steps: 10 });
+  await page.mouse.up();`);
+
+    expect(sources.get('Python')!.text).toContain(``);
+
+    expect(sources.get('Python Async')!.text).toContain(``);
+
+    expect(sources.get('Java')!.text).toContain(``);
+
+    expect(sources.get('C#')!.text).toContain(``);
+
+    expect(message.text()).toBe('mouseup 450 450');
+  });
+
   test('should work with TrustedTypes', async ({ openRecorder }) => {
     const { page, recorder } = await openRecorder();
 


### PR DESCRIPTION
move or click event is fired
move event output not working yet

```bash
npm run watch
npm test -- tests/library/inspector/cli-codegen-1.spec.ts --headed --project=chromium-library


npm run eslint -- --fix

npm run publish playwright-core-x -w packages/playwright-core
```